### PR TITLE
Indri-based answer producer

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -94,6 +94,11 @@ func (lqa *LiveQA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	q.ReceivedTime = time.Now()
 
+	// Drop query if without a proper Qid
+	if len(q.Qid) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	log.Println("QID", q.Qid)
 
 	// Process query here

--- a/handler.go
+++ b/handler.go
@@ -99,7 +99,7 @@ func (lqa *LiveQA) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	log.Println("QID", q.Qid)
+	log.Println("IP", r.RemoteAddr, "QID", q.Qid)
 
 	// Process query here
 	a := lqa.ProcessQuestion(q)

--- a/indri.go
+++ b/indri.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Run the query, and dump the top-1 document content
+func IndriGetTopDocument(repo string, query string) string {
+	out, err := exec.Command(
+		"IndriRunQuery", "-index="+repo,
+		"-trecFormat=1", "-count=1",
+		"-query.text="+query).Output()
+	if err != nil {
+		return err.Error()
+	}
+	fields := strings.Fields(string(out))
+	docno := fields[2]
+
+	out, err = exec.Command(
+		"dumpindex", repo, "documentid", "docno", docno).Output()
+	if err != nil {
+		return err.Error()
+	}
+	internal_docno := strings.TrimSpace(string(out))
+
+	out, err = exec.Command(
+		"dumpindex", repo, "documenttext", internal_docno).Output()
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
+}
+
+func Summarize(content string, limit int) string {
+	lines := strings.Split(content, "\n")
+	var buf bytes.Buffer
+	var ok = false
+	for _, line := range lines {
+		switch {
+		case buf.Len() > limit:
+			break
+		case strings.HasPrefix(line, "<TEXT>"):
+			ok = true
+		case strings.HasPrefix(line, "</TEXT>"):
+			ok = false
+		case ok:
+			buf.WriteString(line + " ")
+		}
+	}
+
+	if buf.Len() > limit-5 {
+		buf.Truncate(limit - 5)
+		return buf.String() + "..."
+	} else {
+		return buf.String()
+	}
+}
+
+type IndriIndexAnswerProducer struct {
+	Repository string
+}
+
+func (ap *IndriIndexAnswerProducer) GetAnswer(result chan *Answer, q *Question) {
+	content := IndriGetTopDocument(ap.Repository, q.Title)
+	summary := Summarize(content, 250)
+	result <- &Answer{
+		Answered:  "yes",
+		Pid:       "demo-id-02",
+		Qid:       q.Qid,
+		Time:      int64(time.Since(q.ReceivedTime) / time.Millisecond),
+		Content:   summary,
+		Resources: "resource1,resource2",
+	}
+}

--- a/indri.go
+++ b/indri.go
@@ -5,10 +5,25 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
 )
+
+func Sanitize(r rune) rune {
+	switch {
+	case unicode.IsPunct(r):
+		return ' '
+	case unicode.IsMark(r):
+		return ' '
+	case unicode.IsSymbol(r):
+		return ' '
+	}
+	return r
+}
 
 // Run the query, and dump the top-1 document content
 func IndriGetTopDocument(repo string, query string) string {
+	query = strings.Map(Sanitize, query)
+
 	out, err := exec.Command(
 		"IndriRunQuery", "-index="+repo,
 		"-trecFormat=1", "-count=1",

--- a/main.go
+++ b/main.go
@@ -1,17 +1,45 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 )
 
 func main() {
-	// Create a liveQA listener with a timeout of 3 seconds
-	lqa := NewLiveQA(3)
+	timeout_ := flag.Int("timeout", 30, "timeout, in seconds")
+	port_ := flag.Int("port", 8080, "HTTP service port")
+	logfile_ := flag.String("logfile", "liveqa.log", "path to log file")
+	index_ := flag.String("index", "", "path to Indri index")
+	flag.Parse()
+
+	// Create a liveQA listener with a timeout of 30 seconds
+	lqa := NewLiveQA(*timeout_)
+
 	// Add a dummy answer producer to it
 	lqa.AddProducer(&DummyAnswerProducer{})
 
+	// Add an indri index answer producer
+	if _, err := os.Stat(*index_); err != nil {
+		log.Fatalf("[flag -index] %s", err)
+		return
+	}
+	lqa.AddProducer(&IndriIndexAnswerProducer{*index_})
+
 	http.Handle("/", lqa)
 
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	// Set up logging
+	logfile, err := os.OpenFile(*logfile_,
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err == nil {
+		log.SetOutput(io.MultiWriter(os.Stderr, logfile))
+	} else {
+		log.Fatalf("[flag -logfile] %s", err)
+		log.Fatalln("will carry on without the logfile")
+	}
+
+	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port_), nil))
 }


### PR DESCRIPTION
Implemented a simple answer producer that simply fetches top 1 document from indri index by making shell calls to `IndriRunQuery` and `dumpindex` (which doesn't work over sockets) and returns the top 250 characters.  

Other minor changes include: Added flag support; Log output can be tee'd to some logfile.  The code is slightly too verbal though.
